### PR TITLE
Fix huggingface untrusted repo error

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -64,7 +64,7 @@ cd /d "%NETRYX_DIR%"
 :: Pre-download MegaLoc weights
 echo.
 echo [SETUP] Downloading MegaLoc model weights ^(first time only^)...
-python -c "import torch; model = torch.hub.load('gmberton/MegaLoc', 'get_trained_model'); print('[OK] MegaLoc ready')" 2>nul
+python -c "import torch; model = torch.hub.load('gmberton/MegaLoc', 'get_trained_model', trust_repo=True); print('[OK] MegaLoc ready')" 2>nul
 if errorlevel 1 echo [WARN] MegaLoc download failed - will retry on first run
 
 :: Pre-download MASt3R weights

--- a/setup.sh
+++ b/setup.sh
@@ -62,7 +62,7 @@ cd "$SCRIPT_DIR"
 python3 -c "
 import torch
 try:
-    model = torch.hub.load('gmberton/MegaLoc', 'get_trained_model')
+    model = torch.hub.load('gmberton/MegaLoc', 'get_trained_model', trust_repo=True)
     print('✅ MegaLoc weights downloaded')
 except Exception as e:
     print(f'⚠️  MegaLoc download failed: {e}')


### PR DESCRIPTION
The MegaLoc weights installation step of both setup scripts had an issue where they didn't specify that the MegaLoc repository was trusted that made the installer wait silently forever.

This was fixed by adding the trust_repo=True variable to both scripts.